### PR TITLE
bundle update at 2020-04-06 01:00:51 UTC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/activeadmin/activeadmin.git
-  revision: ccbe5cb0c451b374995cc1c8316732583fd4eed3
+  revision: 507ac28081211afdbe4817cf32ddadc46b4febaa
   specs:
-    activeadmin (2.6.1)
+    activeadmin (2.7.0)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (~> 3.1)
       formtastic_i18n (~> 0.4)
@@ -127,7 +127,7 @@ GEM
       capistrano (~> 3.7)
       capistrano-bundler
       puma (~> 4.0)
-    capybara (3.31.0)
+    capybara (3.32.1)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -167,7 +167,7 @@ GEM
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
-    foreman (0.87.0)
+    foreman (0.87.1)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
@@ -224,7 +224,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -282,7 +282,7 @@ GEM
       rack
     orm_adapter (0.5.0)
     parallel (1.19.1)
-    parser (2.7.0.5)
+    parser (2.7.1.0)
       ast (~> 2.4.0)
     pg (1.2.3)
     polyamorous (2.3.2)
@@ -298,7 +298,7 @@ GEM
       yard (~> 0.9.11)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (4.0.3)
+    public_suffix (4.0.4)
     puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.2.2)
@@ -369,17 +369,17 @@ GEM
     rspec-support (3.9.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.80.1)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
       rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
-    rubocop-rails (2.5.0)
+    rubocop-rails (2.5.1)
       activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -433,9 +433,9 @@ GEM
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
     uniform_notifier (1.13.0)
     warden (1.2.8)
       rack (>= 2.0.6)


### PR DESCRIPTION
**Updated RubyGems:**

* [x] [activeadmin](https://github.com/activeadmin/activeadmin): [`ccbe5cb0c451b374995cc1c8316732583fd4eed3...507ac28081211afdbe4817cf32ddadc46b4febaa`](https://github.com/activeadmin/activeadmin/compare/ccbe5cb0c451b374995cc1c8316732583fd4eed3...507ac28081211afdbe4817cf32ddadc46b4febaa)
* [x] [capybara](https://github.com/teamcapybara/capybara): [`3.31.0...3.32.1`](https://github.com/teamcapybara/capybara/compare/3.31.0...3.32.1)
* [x] [foreman](https://github.com/ddollar/foreman): [`0.87.0...0.87.1`](https://github.com/ddollar/foreman/compare/v0.87.0...v0.87.1)
* [x] [loofah](https://github.com/flavorjones/loofah): [`2.4.0...2.5.0`](https://github.com/flavorjones/loofah/compare/v2.4.0...v2.5.0)
* [x] [parser](https://github.com/whitequark/parser): [`2.7.0.5...2.7.1.0`](https://github.com/whitequark/parser/compare/v2.7.0.5...v2.7.1.0)
* [x] [public_suffix](https://github.com/weppos/publicsuffix-ruby): [`4.0.3...4.0.4`](https://github.com/weppos/publicsuffix-ruby/compare/4.0.3...v4.0.4)
* [x] [rubocop](https://github.com/rubocop-hq/rubocop): [`0.80.1...0.81.0`](https://github.com/rubocop-hq/rubocop/compare/v0.80.1...v0.81.0)
* [x] [rubocop-rails](https://github.com/rubocop-hq/rubocop-rails): [`2.5.0...2.5.1`](https://github.com/rubocop-hq/rubocop-rails/compare/v2.5.0...v2.5.1)
* [x] [tzinfo](https://github.com/tzinfo/tzinfo): [`1.2.6...1.2.7`](https://github.com/tzinfo/tzinfo/compare/v1.2.6...v1.2.7)
* [x] [unicode-display_width](https://github.com/janlelis/unicode-display_width): [`1.6.1...1.7.0`](https://github.com/janlelis/unicode-display_width/compare/v1.6.1...v1.7.0)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
