### PR TITLE
bundle update at 2020-04-20 01:03:21 UTC

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/activeadmin/activeadmin.git
-  revision: 8afc4175e19f067b199c6d1249aa302ddab09349
+  revision: fdb7d8ecc1aa895f12e9526f7d622b00c550e2d8
   specs:
     activeadmin (2.7.0)
       arbre (~> 1.2, >= 1.2.1)
@@ -86,7 +86,7 @@ GEM
     ast (2.4.0)
     awesome_print (1.8.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.296.0)
+    aws-partitions (1.298.0)
     aws-sdk-core (3.94.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
@@ -99,7 +99,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.83.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.1.1)
+    aws-sigv4 (1.1.2)
       aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.13)
     better_errors (2.6.0)
@@ -115,7 +115,7 @@ GEM
     bullet (6.1.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (11.1.1)
+    byebug (11.1.2)
     capistrano (3.13.0)
       airbrussh (>= 1.0.0)
       i18n
@@ -299,7 +299,7 @@ GEM
       rack
     orm_adapter (0.5.0)
     parallel (1.19.1)
-    parser (2.7.1.0)
+    parser (2.7.1.1)
       ast (~> 2.4.0)
     pg (1.2.3)
     polyamorous (2.3.2)
@@ -389,7 +389,7 @@ GEM
     rspec-support (3.9.2)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (0.81.0)
+    rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -408,7 +408,7 @@ GEM
       ffi (~> 1.9)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
-    sassc (2.2.1)
+    sassc (2.3.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
@@ -466,7 +466,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    webdrivers (4.2.0)
+    webdrivers (4.3.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (>= 3.0, < 4.0)


### PR DESCRIPTION
**Updated RubyGems:**

* [x] [activeadmin](https://github.com/activeadmin/activeadmin): [`8afc4175e19f067b199c6d1249aa302ddab09349...fdb7d8ecc1aa895f12e9526f7d622b00c550e2d8`](https://github.com/activeadmin/activeadmin/compare/8afc4175e19f067b199c6d1249aa302ddab09349...fdb7d8ecc1aa895f12e9526f7d622b00c550e2d8)
* [x] [aws-partitions](https://github.com/aws/aws-sdk-ruby): `1.296.0...1.298.0`
* [x] [aws-sigv4](https://github.com/aws/aws-sdk-ruby): [`1.1.1...1.1.2`](https://github.com/aws/aws-sdk-ruby/compare/1.1.1...1.1.2)
* [x] [byebug](https://github.com/deivid-rodriguez/byebug): [`11.1.1...11.1.2`](https://github.com/deivid-rodriguez/byebug/compare/v11.1.1...v11.1.2)
* [x] [parser](https://github.com/whitequark/parser): [`2.7.1.0...2.7.1.1`](https://github.com/whitequark/parser/compare/v2.7.1.0...v2.7.1.1)
* [x] [rubocop](https://github.com/rubocop-hq/rubocop): [`0.81.0...0.82.0`](https://github.com/rubocop-hq/rubocop/compare/v0.81.0...v0.82.0)
* [x] [sassc](https://github.com/sass/sassc-ruby): [`2.2.1...2.3.0`](https://github.com/sass/sassc-ruby/compare/v2.2.1...v2.3.0)
* [x] [webdrivers](https://github.com/titusfortner/webdrivers): [`4.2.0...4.3.0`](https://github.com/titusfortner/webdrivers/compare/v4.2.0...v4.3.0)

Powered by [circleci-bundle-update-pr](https://rubygems.org/gems/circleci-bundle-update-pr)
